### PR TITLE
feat(ber encoding): Adds type to Ember.ParameterContents objects. All…

### DIFF
--- a/ber.js
+++ b/ber.js
@@ -279,7 +279,15 @@ ExtendedWriter.prototype.writeReal = function(value, tag) {
 }
 
 ExtendedWriter.prototype.writeValue = function(value, tag) {
-    if(Number.isInteger(value)) {
+    // accepts Ember.ParameterContents for enforcing real types
+     if(typeof value === 'object' && value.type && value.type.key && value.type.key.length && typeof value.type.key === 'string') {
+         if(value.type.key === 'real') {
+            this.writeReal(value.value, tag);
+            return
+         }
+     }
+
+     if(Number.isInteger(value)) {
         if (tag === undefined) {
             tag = EMBER_INTEGER;
         }

--- a/ember.js
+++ b/ember.js
@@ -2074,9 +2074,14 @@ var ParameterType = new Enum({
 module.exports.ParameterAccess = ParameterAccess;
 module.exports.ParameterType = ParameterType;
 
-function ParameterContents(value) {
+function ParameterContents(value, type) {
     if(value !== undefined) {
         this.value = value;
+    }
+    if(type !== undefined) {
+        if((type = ParameterType.get(type)) !== undefined){
+            this.type = type
+        }
     }
 };
 


### PR DESCRIPTION
…ows for explicitly setting Real ParameterContents types to enforce correct encoding.

Solves a problem where 1.0 and 1 can't be distringuished by Number.parseInteger(). This results in Real properties wrongly being encoded to Integers, which breaks the protocol.