### PR TITLE
fix `DeviceTree.getDirectory`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+    "env": {
+        "es6": true,
+        "node": true,
+        "jest": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2015
+    },
+    "rules": {
+        "no-unused-vars": "warn",
+        "no-undef": "warn",
+        "no-redeclare": "warn",
+        "no-extra-semi": "warn",
+        "no-console": "warn",
+        "semi-style":
+            [
+                "error",
+                "last"
+            ]
+    }
+}
+;

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# intellij, pycharm, webstorm...
+/.idea/*
+
 node_modules
 .*.swp

--- a/device.js
+++ b/device.js
@@ -43,7 +43,7 @@ function DeviceTree(host, port = 9000) {
 
     self.client.on('emberTree', (root) => {
         if (root instanceof ember.InvocationResult) {
-            self.emit('invocationResult', root)
+            self.emit('invocationResult', root);
             if (self._debug) {
                 console.log("Received InvocationResult", root);
             }
@@ -66,17 +66,17 @@ util.inherits(DeviceTree, EventEmitter);
 var DecodeBuffer = function (packet) {
     var ber = new BER.Reader(packet);
     return ember.Root.decode(ber);
-}
+};
 
 DeviceTree.prototype.saveTree = function (f) {
     var writer = new BER.Writer();
     this.root.encode(writer);
     f(writer.buffer);
-}
+};
 
 DeviceTree.prototype.isConnected = function () {
     return ((this.client !== undefined) && (this.client.isConnected()));
-}
+};
 
 DeviceTree.prototype.connect = function (timeout = 2) {
     return new Promise((resolve, reject) => {
@@ -92,7 +92,7 @@ DeviceTree.prototype.connect = function (timeout = 2) {
         }
         this.client.connect(timeout);
     });
-}
+};
 
 DeviceTree.prototype.expand = function (node) {
     let self = this;
@@ -129,7 +129,7 @@ DeviceTree.prototype.expand = function (node) {
         }
         return p;
     });
-}
+};
 
 function isDirectSubPathOf(path, parent) {
     return path.lastIndexOf('.') === parent.length && path.startsWith(parent)
@@ -187,7 +187,7 @@ DeviceTree.prototype.getDirectory = function (qnode) {
 };
 
 DeviceTree.prototype.invokeFunction = function (fnNode, params) {
-    var self = this
+    var self = this;
     return new Promise((resolve, reject) => {
         self.addRequest((error) => {
             if (error) {
@@ -202,7 +202,7 @@ DeviceTree.prototype.invokeFunction = function (fnNode, params) {
                     reject(error);
                 }
                 else {
-                    if (DEBUG) {
+                    if (self._debug) {
                         console.log("InvocationResult", result);
                     }
                     resolve(result);
@@ -217,13 +217,13 @@ DeviceTree.prototype.invokeFunction = function (fnNode, params) {
             self.client.sendBERNode(fnNode.invoke(params));
         });
     })
-}
+};
 
 DeviceTree.prototype.disconnect = function () {
     if (this.client !== undefined) {
         return this.client.disconnect();
     }
-}
+};
 
 DeviceTree.prototype.makeRequest = function () {
     var self = this;
@@ -248,14 +248,14 @@ DeviceTree.prototype.addRequest = function (cb) {
     var self = this;
     self.pendingRequests.push(cb);
     self.makeRequest();
-}
+};
 
 DeviceTree.prototype.clearTimeout = function () {
     if (this.timeout != null) {
         clearTimeout(this.timeout);
         this.timeout = null;
     }
-}
+};
 
 DeviceTree.prototype.finishRequest = function () {
     var self = this;
@@ -263,13 +263,13 @@ DeviceTree.prototype.finishRequest = function () {
     self.clearTimeout();
     self.activeRequest = null;
     self.makeRequest();
-}
+};
 
 DeviceTree.prototype.timeoutRequest = function (id) {
     var self = this;
     self.root.cancelCallbacks();
     self.activeRequest(new errors.EmberTimeoutError(`Request ${id !== undefined ? id : ""} timed out`));
-}
+};
 
 DeviceTree.prototype.handleRoot = function (root) {
     var self = this;
@@ -294,7 +294,7 @@ DeviceTree.prototype.handleRoot = function (root) {
             callbacks[j]();
         }
     }
-}
+};
 
 DeviceTree.prototype.handleQualifiedNode = function (parent, node) {
     var self = this;
@@ -339,7 +339,7 @@ DeviceTree.prototype.handleQualifiedNode = function (parent, node) {
     //callbacks = parent.update();
 
     return callbacks;
-}
+};
 
 DeviceTree.prototype.handleNode = function (parent, node) {
     var self = this;
@@ -365,7 +365,7 @@ DeviceTree.prototype.handleNode = function (parent, node) {
 
     //console.log('handleNode: ', callbacks);
     return callbacks;
-}
+};
 
 DeviceTree.prototype.getNodeByPath = function (path) {
     var self = this;
@@ -390,7 +390,7 @@ DeviceTree.prototype.getNodeByPath = function (path) {
             });
         });
     });
-}
+};
 
 DeviceTree.prototype.subscribe = function (node, callback) {
     if (node instanceof ember.Parameter && node.isStream()) {
@@ -398,7 +398,7 @@ DeviceTree.prototype.subscribe = function (node, callback) {
     } else {
         node.addCallback(callback);
     }
-}
+};
 
 DeviceTree.prototype.unsubscribe = function (node, callback) {
     if (node instanceof ember.Parameter && node.isStream()) {
@@ -406,7 +406,7 @@ DeviceTree.prototype.unsubscribe = function (node, callback) {
     } else {
         node.addCallback(callback);
     }
-}
+};
 
 DeviceTree.prototype.setValue = function (node, value) {
     var self = this;
@@ -443,7 +443,7 @@ DeviceTree.prototype.setValue = function (node, value) {
             });
         }
     });
-}
+};
 
 function TreePath(path) {
     this.identifiers = [];

--- a/device.js
+++ b/device.js
@@ -149,7 +149,7 @@ DeviceTree.prototype.getDirectory = function (qnode) {
                 return;
             }
 
-            let cb = (error, node) => {
+            self.callback = (error, node) => {
                 const requestedPath = qnode.path != null ? qnode.path : qnode.elements["0"].path;
                 if (error) {
                     if (self._debug) {
@@ -177,7 +177,6 @@ DeviceTree.prototype.getDirectory = function (qnode) {
             if (self._debug) {
                 console.log("Sending getDirectory", qnode);
             }
-            self.callback = cb;
             self.client.sendBERNode(qnode.getDirectory());
         });
     });

--- a/device.js
+++ b/device.js
@@ -177,9 +177,6 @@ DeviceTree.prototype.getDirectory = function (qnode) {
             if (self._debug) {
                 console.log("Sending getDirectory", qnode);
             }
-            if (self._debug && self.callback != null) {
-                console.log("erasing callback");
-            }
             self.callback = cb;
             self.client.sendBERNode(qnode.getDirectory());
         });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Javascript implementation of the Ember+ automation protocol",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest test",
+    "eslint": "eslint ./"
   },
   "author": "Brian Mayton <bmayton@bdm.cc> (http://bdm.cc)",
   "contributors": [
@@ -24,5 +25,9 @@
     "long": "^3.2.0",
     "smart-buffer": "^3.0.3",
     "winston-color": "^1.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.5.0",
+    "jest": "^23.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/bmayton/node-emberplus"
-  },    
+  },
   "license": "MIT",
   "dependencies": {
-    "asn1": "evs-broadcast/node-asn1",
+    "asn1": "evs-broadcast/node-asn1#date_2018_01_02",
     "enum": "^2.4.0",
     "long": "^3.2.0",
     "smart-buffer": "^3.0.3",

--- a/test/DeviceTree.test.js
+++ b/test/DeviceTree.test.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+const Decoder = require('../').Decoder;
+const DeviceTree = require("../").DeviceTree;
+const TreeServer = require("../").TreeServer;
+
+const LOCALHOST = "127.0.0.1";
+const PORT = 9008;
+
+describe("DeviceTree", () => {
+    let server;
+
+    beforeAll(() => {
+        return Promise.resolve()
+            .then(() => new Promise((resolve, reject) => {
+                fs.readFile("./embrionix.ember", (e, data) => {
+                    if (e) {
+                        reject(e);
+                    }
+                    resolve(Decoder(data));
+                });
+            }))
+            .then(root => {
+                server = new TreeServer(LOCALHOST, PORT, root);
+                return server.listen();
+            });
+    });
+
+    afterAll(() => server.close());
+
+    it("should gracefully connect and disconnect", () => {
+        return Promise.resolve()
+            .then(() => {
+                let tree = new DeviceTree(LOCALHOST, PORT);
+                return Promise.resolve()
+                    .then(() => tree.connect())
+                    .then(() => tree.getDirectory())
+                    .then(() => tree.disconnect())
+                    .then(() => tree.connect())
+                    .then(() => tree.getDirectory())
+                    .then(() => tree.disconnect())
+            })
+    });
+});

--- a/test/device.test.js
+++ b/test/device.test.js
@@ -1,0 +1,5 @@
+describe("DeviceTree", () => {
+    it("expect true", () => {
+        expect(true).toBe(true);
+    })
+});

--- a/test/device.test.js
+++ b/test/device.test.js
@@ -1,5 +1,0 @@
-describe("DeviceTree", () => {
-    it("expect true", () => {
-        expect(true).toBe(true);
-    })
-});


### PR DESCRIPTION
The `DeviceTree.getDirectory` function used to resolve on the first incoming `emberTree` event but it might be another part of the tree that send its update.

This PR:
- resolve the `DeviceTree.getDirectory` promise if the incoming data is related to the queried node.
- add basic eslint configured to only produce waning on current codebase
- add jest and unit test for the previously fixed disconnect functionality
- target a git tag fo `node-asn1`
- fixed some eslint wanings related to missing semi-colon in `device.js`
- add .gitignore
- redirect the left alone `DEBUG` do `DeviceTree._debug` in `device.js`
