### PR TITLE
Fix: Server crash on client connection reset

### DIFF
--- a/sample.js
+++ b/sample.js
@@ -2,14 +2,17 @@ const Decoder = require('.').Decoder;
 const DeviceTree = require(".").DeviceTree;
 const fs = require("fs");
 
-const LOCALHOST = "127.0.0.1";
-const PORT = 9008;
+const LOCALHOST = "0.0.0.0";
+const PORT = 3336;
 
 fs.readFile("./embrionix.ember", (e, data) => {
     let root = Decoder(data);
 
     const TreeServer = require("./").TreeServer;
     const server = new TreeServer(LOCALHOST, PORT, root);
+    server.on("clientError", (e) => {
+        console.log(e);
+    });
     server.listen()
         .then(() => {
             console.log("listening");

--- a/server.js
+++ b/server.js
@@ -45,6 +45,9 @@ function TreeServer(host, port, tree) {
             self.clients.delete(client);
             self.emit('disconnect', client.remoteAddress());
         });
+        client.on("error", error => {
+            self.emit('clientError', { remoteAddress: client.remoteAddress(), error });
+        });
         self.emit('connection', client.remoteAddress());
     });
 


### PR DESCRIPTION
send clientError event when receiving an error from a client connection
this handle an unhandled exception

this should fix: #23 Server crash on client connection reset