### PR TITLE
device.js#DeviceTree.getDirectory(): using node instead of qnode for …

### DIFF
--- a/device.js
+++ b/device.js
@@ -160,7 +160,7 @@ DeviceTree.prototype.getDirectory = function (qnode) {
                     reject(error);
                     return;
                 }
-                const requestedPath = qnode.path != null ? qnode.path : qnode.elements["0"].path;
+                const requestedPath = node.path != null ? node.path : node.elements[0].path;
                 const nodeElements = node == null ? null : node.elements;
                 if (nodeElements != null
                     && nodeElements.every(el => el.path === requestedPath || isDirectSubPathOf(el.path, requestedPath))) {


### PR DESCRIPTION
Hello,
at first, thanks to all contributors for bringing Ember+ to node.js 👍 

When i tried to run the DeviceTree example from `README.md` against the TinyEmber app i got an error saying `TypeError: Cannot read property '0' of undefined` in line 163 of `device.js`.

Besides for the root node, `qnode` has no prop `elements`, so it crashes. Changing it to `node` makes it work.
Since `node.elements` is an Array i got rid of the double-quotes around the index.


