### PR TITLE
Fix parameter toQualified function

### DIFF
--- a/ember.js
+++ b/ember.js
@@ -2297,7 +2297,7 @@ Parameter.prototype.setValue = function(value, callback) {
 }
 
 Parameter.prototype.toQualified = function() {
-    let qp = new QualifiedNode(this.getPath());
+    let qp = new QualifiedParameter(this.getPath());
     qp.update(this);
     return qp;
 }


### PR DESCRIPTION
Hello,

when I try to update a parameter using EmBER+Viewer the response contains a qualified node instead of a qualified parameter.

The patch contains a possible fix for that problem.