### PR TITLE
Fix unhandled error

### DIFF
--- a/device.js
+++ b/device.js
@@ -278,7 +278,11 @@ DeviceTree.prototype.finishRequest = function () {
     self.callback = undefined;
     self.clearTimeout();
     self.activeRequest = null;
-    self.makeRequest();
+    try {
+        self.makeRequest();
+    } catch(e) {
+        console.log("warn:" + e.message)
+    }
 };
 
 DeviceTree.prototype.timeoutRequest = function (id) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emberplus",
-  "version": "1.7.22",
+  "version": "1.7.23",
   "description": "Javascript implementation of the Ember+ automation protocol",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "eslint": "^5.5.0",
-    "jest": "^23.5.0"
+    "jest": "^23.5.0",
+    "sinon": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "eslint": "^5.5.0",
     "jest": "^23.5.0",
-    "sinon": "latest"
+    "sinon": "^7.4.1"
   }
 }

--- a/test/DeviceTree.test.js
+++ b/test/DeviceTree.test.js
@@ -1,7 +1,9 @@
 const fs = require("fs");
+const sinon = require("sinon");
 const Decoder = require('../').Decoder;
 const DeviceTree = require("../").DeviceTree;
 const TreeServer = require("../").TreeServer;
+const S101Client = require("../").S101Client;
 
 const LOCALHOST = "127.0.0.1";
 const UNKNOWN_HOST = "192.168.99.99";
@@ -9,6 +11,7 @@ const PORT = 9008;
 
 describe("DeviceTree", () => {
     describe("With server", () => {
+        /** @type {TreeServer} */
         let server;
         beforeAll(() => {
             return Promise.resolve()
@@ -42,6 +45,26 @@ describe("DeviceTree", () => {
                 })
         });
 
+        it("should gracefully connect and getDirectory", () => {
+            let tree = new DeviceTree(LOCALHOST, PORT);
+            let stub = sinon.stub(tree.client, "sendBER");
+            stub.onFirstCall().returns();
+            stub.onSecondCall().throws(new Error("blah"));
+            stub.callThrough();
+            return Promise.resolve()
+                .then(() => tree.connect())
+                .then(() => {tree.getDirectory().catch(() => {})})
+                .then(() => tree.getDirectory())
+                .then(() => {
+                    stub.restore();
+                    tree.disconnect();
+                }, error => {
+                    stub.restore();
+                    tree.disconnect();
+                    throw error;
+                })
+
+        }, 10000);
         it("should not disconnect after 5 seconds of inactivity", () => {
             return Promise.resolve()
                 .then(() => {

--- a/test/DeviceTree.test.js
+++ b/test/DeviceTree.test.js
@@ -3,7 +3,6 @@ const sinon = require("sinon");
 const Decoder = require('../').Decoder;
 const DeviceTree = require("../").DeviceTree;
 const TreeServer = require("../").TreeServer;
-const S101Client = require("../").S101Client;
 
 const LOCALHOST = "127.0.0.1";
 const UNKNOWN_HOST = "192.168.99.99";


### PR DESCRIPTION
Fix an unhandled error when client is disconnected while trying to send command to a device.
If there was a timeout beforehand, the error was not catched.